### PR TITLE
CDE-381-cas-de-fichier-avec-header-incorrect-non-bloque :

### DIFF
--- a/src/main/java/fr/abes/kbart2kafka/Kbart2kafkaApplication.java
+++ b/src/main/java/fr/abes/kbart2kafka/Kbart2kafkaApplication.java
@@ -68,7 +68,7 @@ public class Kbart2kafkaApplication implements CommandLineRunner {
         }
         long endTime = System.currentTimeMillis();
         double executionTime = (double) (endTime - startTime) / 1000;
-        log.info("Temps d'exécution : " + executionTime + " secondes");
+        log.debug("Temps d'exécution : " + executionTime + " secondes");
     }
 
     private void checkExistingPackage(String filename) throws IllegalProviderException, IllegalPackageException, IllegalDateException {

--- a/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
+++ b/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
@@ -81,10 +81,13 @@ public class CheckFiles {
             if(isBypassOptionPresent && line.contains("best_ppn")) {
                 log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
                 throw new IllegalFileFormatException("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.");
-            } else if(headerKbart.length == 25 && !line.contains(header)) {
+            } else if (headerKbart.length <24 || headerKbart.length > 26) {
                 log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
                 throw new IllegalFileFormatException("L'en tete du fichier est incorrecte.");
-            } else if(headerKbart.length == 26 && !line.contains("best_ppn")) {
+            } else if(headerKbart.length <= 25 && !line.contains(header)) {
+                log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
+                throw new IllegalFileFormatException("L'en tete du fichier est incorrecte.");
+            } else if((headerKbart.length == 26 && !line.contains("best_ppn"))) {
                 log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
                 throw new IllegalFileFormatException("L'en tete du fichier est incorrecte.");
             }

--- a/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
+++ b/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
@@ -76,10 +76,15 @@ public class CheckFiles {
     public static void detectHeaderPresence(String header, File file, Boolean isBypassOptionPresent) throws IOException, IllegalFileFormatException {
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             String line = reader.readLine();
+            String[] headerKbart = line.split("\t");
+
             if(isBypassOptionPresent && line.contains("best_ppn")) {
                 log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
                 throw new IllegalFileFormatException("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.");
-            } else if(!line.contains(header)) {
+            } else if(headerKbart.length == 25 && !line.contains(header)) {
+                log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
+                throw new IllegalFileFormatException("L'en tete du fichier est incorrecte.");
+            } else if(headerKbart.length == 26 && !line.contains("best_ppn")) {
                 log.error("Message envoyé : {}", "L'en tete du fichier est incorrecte.");
                 throw new IllegalFileFormatException("L'en tete du fichier est incorrecte.");
             }

--- a/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
@@ -18,6 +18,9 @@ class CheckFilesTest {
     File file1;
     File file2;
     File file3;
+    File file4;
+    File file5;
+    File file6;
 
     @AfterEach
     public void cleanUp() {
@@ -25,6 +28,9 @@ class CheckFilesTest {
         if(file1 != null && file1.delete()){file1.deleteOnExit();}     // ne pas supprimer. Indispensable pour que les TU fonctionnent.
         if(file2 != null && file2.delete()){file2.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
         if(file3 != null  && file3.delete()){file3.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
+        if(file4 != null && file4.delete()){file4.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
+        if(file5 != null && file5.delete()){file5.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
+        if(file6 != null && file6.delete()){file6.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
     }
 
     @Test
@@ -107,19 +113,23 @@ class CheckFilesTest {
         IllegalFileFormatException erreur3 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\best_ppn", file3, false));
         Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur3.getMessage());
 
-        // Test avec header à 24 colonnes
-        File file4 = new File("test2.tsv");
-        FileUtils.writeStringToFile(file4, "testB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
-        IllegalFileFormatException erreur4 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file4, false));
+        // Test d'une erreur sur le header à 2 colonnes avec une colonne bestPpn
+        this.file4 = new File("test4.tsv");
+        FileUtils.writeStringToFile(file4, "testA\ttestB\tbest_ppn", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur4 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\tbest_ppn", file4, false));
         Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur4.getMessage());
-        file4.deleteOnExit();
 
-        // Test avec header à 27 colonnes
-        File file5 = new File("test2.tsv");
+        // Test avec header à 24 colonnes
+        this.file5 = new File("test5.tsv");
         FileUtils.writeStringToFile(file5, "testB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur5 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file5, false));
         Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur5.getMessage());
-        file5.deleteOnExit();
+
+        // Test avec header à 27 colonnes
+        this.file6 = new File("test6.tsv");
+        FileUtils.writeStringToFile(file6, "testB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur6 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file6, false));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur6.getMessage());
     }
 
     @Test

--- a/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
@@ -106,6 +106,20 @@ class CheckFilesTest {
         FileUtils.writeStringToFile(file3, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\ttestZZZ", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur3 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\best_ppn", file3, false));
         Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur3.getMessage());
+
+        // Test avec header à 24 colonnes
+        File file4 = new File("test2.tsv");
+        FileUtils.writeStringToFile(file4, "testB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur4 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file4, false));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur4.getMessage());
+        file4.deleteOnExit();
+
+        // Test avec header à 27 colonnes
+        File file5 = new File("test2.tsv");
+        FileUtils.writeStringToFile(file5, "testB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur5 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file5, false));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur5.getMessage());
+        file5.deleteOnExit();
     }
 
     @Test

--- a/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
@@ -15,12 +15,14 @@ import java.nio.charset.StandardCharsets;
 class CheckFilesTest {
 
     File file;
+    File file1;
     File file2;
     File file3;
 
     @AfterEach
     public void cleanUp() {
         if(file != null && file.delete()){file.deleteOnExit();}    // ne pas supprimer. Indispensable pour que les TU fonctionnent.
+        if(file1 != null && file1.delete()){file1.deleteOnExit();}     // ne pas supprimer. Indispensable pour que les TU fonctionnent.
         if(file2 != null && file2.delete()){file2.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
         if(file3 != null  && file3.delete()){file3.deleteOnExit();}  // ne pas supprimer. Indispensable pour que les TU fonctionnent.
     }
@@ -84,13 +86,26 @@ class CheckFilesTest {
     @Test
     void detectOfHeaderPresence() throws IOException, IllegalFileFormatException {
         this.file = new File("test.tsv");
-        FileUtils.writeStringToFile(file, "test\ttest\ttest", StandardCharsets.UTF_8, true);
-        CheckFiles.detectHeaderPresence("test", file, false);
+        FileUtils.writeStringToFile(file, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
+        CheckFiles.detectHeaderPresence("testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file, false);
 
+        // Test d'une erreur sur le header avec bestPpn est option byPass
+        this.file1 = new File("test1.tsv");
+        FileUtils.writeStringToFile(file1, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\tbest_ppn", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur1 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\tbest_ppn", file1, true));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.", erreur1.getMessage());
+
+        // Test d'une erreur sur le header à 25 colonnes
         this.file2 = new File("test2.tsv");
-        FileUtils.writeStringToFile(file2, "toto\ttata\ttiti", StandardCharsets.UTF_8, true);
-        IllegalFileFormatException erreur = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("test", file2, false));
-        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur.getMessage());
+        FileUtils.writeStringToFile(file2, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur2 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ", file2, false));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur2.getMessage());
+
+        // Test d'une erreur sur le header à 26 colonnes avec une colonne bestPpn
+        this.file3 = new File("test3.tsv");
+        FileUtils.writeStringToFile(file3, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\ttestZZZ", StandardCharsets.UTF_8, true);
+        IllegalFileFormatException erreur3 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("testAAA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestX\ttestY\ttestZ\best_ppn", file3, false));
+        Assertions.assertEquals("L'en tete du fichier est incorrecte.", erreur3.getMessage());
     }
 
     @Test


### PR DESCRIPTION
     - ajout d'un contrôle et modification d'un contrôle dans la méthode detectHeaderPresence() (CheckFiles.java)
     - adaptation des TU