### PR TITLE
Merge pour intégration de la CDE403 - Correctif

### DIFF
--- a/README-developpement.md
+++ b/README-developpement.md
@@ -52,6 +52,8 @@ spring.jpa.bacon.hibernate.ddl-auto=none
 spring.jpa.bacon.show-sql=false
 spring.sql.bacon.init.mode=never
 ```
+Pour lancer le projet en local les instructions peuvent être trouvées à cet emplacement :
+![https://git.abes.fr/colodus/kafka-convergence-bacon-conf/-/blob/main/configurations-spring-locales/kbart2kafka/application-localhost.properties?ref_type=heads](https://git.abes.fr/colodus/kafka-convergence-bacon-conf/-/blob/main/configurations-spring-locales/kbart2kafka/application-localhost.properties?ref_type=heads)
 
 ## Traitement du fichier
 *(class `FileService.java`)*

--- a/README-developpement.md
+++ b/README-developpement.md
@@ -14,6 +14,8 @@ L'utilisateur lance le chargement d'un fichier kbart à partir de l'application 
 
 Les développeurs et développeuses peuvent lancer le chargement d'un fichier kbart :
 - via une ligne de commande directement à partir du serveur d'installation de l'API `sudo docker exec kbart2kafka java -jar /app/run/kbart2kafka.jar /app/kbart/SPRINGER_GLOBAL_ALLEBOOKS_2023-05-01.tsv` (vérifier que le container docker soit démarré ainsi que la présence des chemins d'accès et du fichier kbart)
+- par défaut à été ouvert le chemin d'accès suivant `/applis/bacon/toLoad` : un mettant un fichier kbart tsv dans ce dossier il sera possible de la lancer via la commande indiquée ci dessus.
+- pour monter un repertoire de l'hôte dans le conteneur faire `docker run -v /chemin/vers/fichier/hote:/app/kbart [...] kbart2kafka`
 - via un IDE (exemple avec IntelliJ) ![configuration de l'IDE intelliJ](documentation/IDE_config.png "configuration de l'IDE IntelliJ")
 
 Ces deux derniers types de lancement sont détaillés sur le gitlab de l'Abes (accès sécurisé) : [git.abes.fr](https://git.abes.fr/colodus/convergence-configuration)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>fr.abes</groupId>
     <artifactId>kbart2kafka</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>kbart2kafka</name>
     <description>chargement d'un fichier kbart dans kafka</description>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.1.0</version>
+            <version>6.1.5</version>
         </dependency>
         <!-- BDD -->
         <dependency>

--- a/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
+++ b/src/main/java/fr/abes/kbart2kafka/utils/CheckFiles.java
@@ -80,13 +80,9 @@ public class CheckFiles {
             String[] headerKbart = line.split("\t");
 
             if(isBypassOptionPresent && line.contains("best_ppn")) {
-                String messageErreur = "L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.";
-                log.error("Message envoyé : {}", messageErreur);
-                throw new IllegalFileFormatException(messageErreur);
+                throw new IllegalFileFormatException("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn");
             }else if ((!(headerKbart.length == 25 && line.contains(header)) && !(headerKbart.length == 26 && line.contains(header) && line.contains("best_ppn")))) {
-                String messageErreur = "L'en tete du fichier est incorrecte. L’en tête devrait être comme ceci : " + header + " et best_ppn";
-                log.error("Message envoyé : {}", messageErreur);
-                throw new IllegalFileFormatException( messageErreur );
+                throw new IllegalFileFormatException( "L'en tete du fichier est incorrecte. L’en tête devrait être comme ceci : " + header + " et best_ppn" );
             }
         }
     }

--- a/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
@@ -110,7 +110,7 @@ class CheckFilesTest {
         this.file2 = new File("test2.tsv");
         FileUtils.writeStringToFile(file2, "testA\ttestB\ttestC\ttestD\ttestE\ttestF\ttestG\ttestH\ttestI\ttestJ\ttestK\ttestL\ttestM\ttestN\ttestO\ttestP\ttestQ\ttestR\ttestS\ttestT\ttestU\ttestV\ttestW\ttestX\ttestY\tbest_ppn", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur2 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence(header, file2, true));
-        Assertions.assertEquals("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.", erreur2.getMessage());
+        Assertions.assertEquals("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn", erreur2.getMessage());
 
         // header à 25 colonnes avec erreur de nom de colonne
         this.file3 = new File("test3.tsv");
@@ -163,7 +163,7 @@ class CheckFilesTest {
         this.file = new File("test3_BYPASS.tsv");
         FileUtils.writeStringToFile(file, "test\ttest\ttest\tbest_ppn", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur1 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectHeaderPresence("test\ttest\ttest\tbest_ppn", file, true));
-        Assertions.assertEquals("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn.", erreur1.getMessage());
+        Assertions.assertEquals("L'en tete du fichier est incorrecte. L'option _BYPASS n'est pas compatible avec la présence d'une colonne best_pnn", erreur1.getMessage());
 
         this.file2 = new File("test3_BYPASS_FORCE.tsv");
         FileUtils.writeStringToFile(file2, "test\ttest\ttest", StandardCharsets.UTF_8, true);


### PR DESCRIPTION
Le fichier .bad est désormais disponible sur /appli/bacon/toLoad uniquement à la fin du traitement de logskbart-api