### PR TITLE
SOA-503 - Autoriser le téléchargement des rapports bad

### DIFF
--- a/src/main/java/fr/abes/kbart2kafka/controller/KbartController.java
+++ b/src/main/java/fr/abes/kbart2kafka/controller/KbartController.java
@@ -79,15 +79,18 @@ public class KbartController {
 
     @GetMapping(value = {"/file/{fileName}", "/file/{path}/{fileName}"})
     public ResponseEntity<?> getFile(@PathVariable(required = false) String path, @PathVariable String fileName) {
-        boolean isReport = ((path != null) && path.equals("report"));
+        boolean isAllowedSubdirectory = path != null
+                && (path.equals("report") || path.equals("bad"));
 
         if (fileName == null || fileName.isEmpty()) {
             return ResponseEntity.badRequest().body("Le paramètre fileName est vide.");
-        } else if ((path != null) && !path.equals("report")){
+        } else if (path != null && !isAllowedSubdirectory) {
             return ResponseEntity.badRequest().body("Le chemin est incorrect");
         }
         try {
-            File fichier = isReport ? new File(pathToKbart + path + File.separator + fileName) : new File(pathToKbart + fileName);
+            File fichier = isAllowedSubdirectory
+                    ? new File(pathToKbart + path + File.separator + fileName)
+                    : new File(pathToKbart + fileName);
 
             if (!fichier.exists()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Le fichier " + fileName + " est introuvable.");

--- a/src/test/java/fr/abes/kbart2kafka/controller/KbartControllerTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/controller/KbartControllerTest.java
@@ -1,0 +1,53 @@
+package fr.abes.kbart2kafka.controller;
+
+import fr.abes.kbart2kafka.service.FileService;
+import fr.abes.kbart2kafka.service.ProviderPackageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+class KbartControllerTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void telechargeUnRapportDepuisLeSousDossierBad() throws IOException {
+        String filename = "TEST_GLOBAL_ALLTITLES_2026-07-21_400.bad";
+        byte[] expectedContent = "LINE\tMESSAGE\n2\tErreur de validation\n"
+                .getBytes(StandardCharsets.UTF_8);
+        Path badDirectory = Files.createDirectories(tempDirectory.resolve("bad"));
+        Files.write(badDirectory.resolve(filename), expectedContent);
+
+        KbartController controller = new KbartController(
+                mock(FileService.class),
+                mock(ProviderPackageService.class));
+        ReflectionTestUtils.setField(
+                controller,
+                "pathToKbart",
+                tempDirectory.toString() + System.getProperty("file.separator"));
+
+        ResponseEntity<?> response = controller.getFile("bad", filename);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        InputStreamResource resource = assertInstanceOf(
+                InputStreamResource.class,
+                response.getBody());
+        try (var inputStream = resource.getInputStream()) {
+            assertArrayEquals(expectedContent, inputStream.readAllBytes());
+        }
+    }
+}


### PR DESCRIPTION
## Problème

Les emails SOA-503 pointent vers `/api/v1/file/bad/{fichier}`, mais le contrôleur de téléchargement n'autorisait que le sous-dossier `report`. Les liens vers les rapports `_400.bad` et `_other.bad` répondaient donc HTTP 400 alors que les fichiers existaient dans le volume partagé.

## Correction

- ajouter `bad` à la liste blanche des sous-dossiers téléchargeables ;
- conserver le rejet des autres sous-dossiers ;
- ajouter un test de régression qui lit réellement un rapport depuis `bad/`.

## Validation

- cycle TDD : test en échec avec HTTP 400 avant correction, puis réussi avec HTTP 200 ;
- test ciblé : 1 test, 0 échec ;
- non-régression hors échecs préexistants de `CheckFilesTest` : 22 tests, 0 échec ;
- suite complète : 30 tests, avec uniquement les 4 assertions `CheckFilesTest` déjà en échec sur `origin/develop` avant cette modification.

Ticket : SOA-503