### PR TITLE
SOA-503 - Promouvoir le téléchargement des rapports bad vers main

### DIFF
--- a/src/main/java/fr/abes/kbart2kafka/controller/KbartController.java
+++ b/src/main/java/fr/abes/kbart2kafka/controller/KbartController.java
@@ -79,15 +79,18 @@ public class KbartController {
 
     @GetMapping(value = {"/file/{fileName}", "/file/{path}/{fileName}"})
     public ResponseEntity<?> getFile(@PathVariable(required = false) String path, @PathVariable String fileName) {
-        boolean isReport = ((path != null) && path.equals("report"));
+        boolean isAllowedSubdirectory = path != null
+                && (path.equals("report") || path.equals("bad"));
 
         if (fileName == null || fileName.isEmpty()) {
             return ResponseEntity.badRequest().body("Le paramètre fileName est vide.");
-        } else if ((path != null) && !path.equals("report")){
+        } else if (path != null && !isAllowedSubdirectory) {
             return ResponseEntity.badRequest().body("Le chemin est incorrect");
         }
         try {
-            File fichier = isReport ? new File(pathToKbart + path + File.separator + fileName) : new File(pathToKbart + fileName);
+            File fichier = isAllowedSubdirectory
+                    ? new File(pathToKbart + path + File.separator + fileName)
+                    : new File(pathToKbart + fileName);
 
             if (!fichier.exists()) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Le fichier " + fileName + " est introuvable.");

--- a/src/test/java/fr/abes/kbart2kafka/controller/KbartControllerTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/controller/KbartControllerTest.java
@@ -1,0 +1,53 @@
+package fr.abes.kbart2kafka.controller;
+
+import fr.abes.kbart2kafka.service.FileService;
+import fr.abes.kbart2kafka.service.ProviderPackageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+class KbartControllerTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void telechargeUnRapportDepuisLeSousDossierBad() throws IOException {
+        String filename = "TEST_GLOBAL_ALLTITLES_2026-07-21_400.bad";
+        byte[] expectedContent = "LINE\tMESSAGE\n2\tErreur de validation\n"
+                .getBytes(StandardCharsets.UTF_8);
+        Path badDirectory = Files.createDirectories(tempDirectory.resolve("bad"));
+        Files.write(badDirectory.resolve(filename), expectedContent);
+
+        KbartController controller = new KbartController(
+                mock(FileService.class),
+                mock(ProviderPackageService.class));
+        ReflectionTestUtils.setField(
+                controller,
+                "pathToKbart",
+                tempDirectory.toString() + System.getProperty("file.separator"));
+
+        ResponseEntity<?> response = controller.getFile("bad", filename);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        InputStreamResource resource = assertInstanceOf(
+                InputStreamResource.class,
+                response.getBody());
+        try (var inputStream = resource.getInputStream()) {
+            assertArrayEquals(expectedContent, inputStream.readAllBytes());
+        }
+    }
+}

--- a/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
+++ b/src/test/java/fr/abes/kbart2kafka/utils/CheckFilesTest.java
@@ -36,11 +36,11 @@ class CheckFilesTest {
 
         this.file2 = new File("");
         IllegalFileFormatException erreur2 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.isFileWithTSVExtension(file2));
-        Assertions.assertEquals("Le nom du fichier est vide", erreur2.getMessage());
+        Assertions.assertEquals("Format du fichier incorrect. Le nom du fichier est vide", erreur2.getMessage());
 
         this.file3 = new File("test2.csv");
         IllegalFileFormatException erreur3 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.isFileWithTSVExtension(file3));
-        Assertions.assertEquals("le fichier n'est pas au format tsv", erreur3.getMessage());
+        Assertions.assertEquals("Format du fichier incorrect. le fichier n'est pas au format tsv", erreur3.getMessage());
     }
 
     @Test
@@ -54,7 +54,7 @@ class CheckFilesTest {
         for(String name : Lists.newArrayList("123", "test_1234-12-12.tsv", "test_test_134-12-12.tsv", "test_test_1344-12-12.tsvf", "test_test_1344-12-123.tsv", "test_test_test_test1_1234-12-12_force.tsv")) {
             this.file3 = new File(name);
             IllegalFileFormatException erreur2 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectFileNameAndReturnIsBypass(file3));
-            Assertions.assertEquals("Le nom du fichier " + name + " n'est pas correct", erreur2.getMessage());
+            Assertions.assertEquals("Format du fichier incorrect. Le nom du fichier " + name + " n'est pas correct", erreur2.getMessage());
         }
     }
 
@@ -82,7 +82,7 @@ class CheckFilesTest {
         this.file2 = new File("test2.tsv");
         FileUtils.writeStringToFile(file2, "test;test;test", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectTabulations(file2));
-        Assertions.assertEquals("Le fichier ne contient pas de tabulation", erreur.getMessage());
+        Assertions.assertEquals("Format du fichier incorrect. Le fichier ne contient pas de tabulation", erreur.getMessage());
     }
 
     @Test
@@ -181,6 +181,6 @@ class CheckFilesTest {
         this.file2 = new File("test3_BYPASS_FORCE.tsv");
         FileUtils.writeStringToFile(file2, "test\ttest\ttest", StandardCharsets.UTF_8, true);
         IllegalFileFormatException erreur2 = Assertions.assertThrows(IllegalFileFormatException.class, () -> CheckFiles.detectFileNameAndReturnIsBypass(file2));
-        Assertions.assertEquals("Le nom du fichier test3_BYPASS_FORCE.tsv n'est pas correct", erreur2.getMessage());
+        Assertions.assertEquals("Format du fichier incorrect. Le nom du fichier test3_BYPASS_FORCE.tsv n'est pas correct", erreur2.getMessage());
     }
 }


### PR DESCRIPTION
## Objet

Promotion de `develop` vers `main` pour finaliser SOA-503.

## Contenu

- autorisation sécurisée du sous-dossier `bad` dans l’API de téléchargement ;
- maintien du rejet des chemins non autorisés ;
- test de régression du téléchargement HTTP ;
- alignement des messages attendus par les tests de contrôle de fichiers.

## Validation

- `mvn test` : 30 tests réussis, 0 échec.